### PR TITLE
Add the staging configuration back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,11 @@ scrape_mlo_co2_since_1974:
 scrape_mlo_co2_since_1958:
 	@$(PIPENVRUN) $(MANAGEPY) scrape_mlo_co2_since_1958
 .PHONY: scrape_mlo_co2_since_1958
+
+dbcheckmigrations:
+	@$(PIPENVRUN) $(MANAGEPY) makemigrations --check
+.PHONY: dbcheckmigrations
+
+dbmigrate:
+	@$(PIPENVRUN) $(MANAGEPY) migrate --noinput
+.PHONY: dbmigrate

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "predeploy": "pipenv run python manage.py migrate --noinput"
+      "predeploy": "make dbmigrate"
     }
   }
 }

--- a/carbondoomsday/settings.py
+++ b/carbondoomsday/settings.py
@@ -12,6 +12,13 @@ class Dokku():
     """Dokku configuration necessities."""
     @classmethod
     def post_setup(cls):
+        """We dynamically configure the `ALLOWED_HOSTS` for Dokku checks.
+
+        Please see the lower part of:
+
+        > http://dokku.viewdocs.io/dokku/deployment/zero-downtime-deploys/#zero-downtime-deploys
+
+        """  # noqa
         super(Dokku, cls).post_setup()
         hostname = socket.gethostname()
         cls.ALLOWED_HOSTS.append(socket.gethostbyname(hostname))

--- a/carbondoomsday/settings.py
+++ b/carbondoomsday/settings.py
@@ -240,6 +240,14 @@ class Base(MLODataSources, RedisCache, GitterWebHooks,
     }
 
 
+class Staging(Dokku, OpbeatCredentials, CORSHeaderAllowAll, Base):
+    """The staging environment."""
+    ENVIRONMENT = 'Staging'
+    ALLOWED_HOSTS = [
+        'api-test.carbondoomsday.com'
+    ]
+
+
 class Production(Dokku, OpbeatCredentials, Base):
     """The production environment."""
     ENVIRONMENT = 'Production'


### PR DESCRIPTION
I'm going to setup `api-test.carbondoomsday.com` with this.

That will have no CORS restrictions on it for the testing environment.

Follows from https://github.com/giving-a-fuck-about-climate-change/carbondoomsday/issues/117.