### PR TITLE
Add missing pluggy package.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -37,7 +37,7 @@ djangorestframework-filters = "*"
 "-e ." = "*"
 dj-database-url = "*"
 drf-yasg = "*"
-
+pluggy = "*"
 
 [requires]
 


### PR DESCRIPTION
@lwm I'm _finally_ getting the email signature up and ready.

I found that my installation was complaining about the missing "pluggy" package - is this an appropriate fix or did I miss something in how I set up my local system?